### PR TITLE
feat: Criar tela 'ver todos' de filmes populares

### DIFF
--- a/lib/view/see_all_popular_movies.dart
+++ b/lib/view/see_all_popular_movies.dart
@@ -35,7 +35,30 @@ class _SeeAllPopularMovies extends State<SeeAllPopularMovies> {
         actions: [IconButton(onPressed: () {}, icon: Icon(Icons.search))],
       ),
       body: Column(
-        children: [],
+        children: [
+          FutureBuilder<List<dynamic>>(
+            future:
+                mediaItems, // Suponha que esta função retorne a lista de mídias.
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.hasError) {
+                  return Center(child: Text('Erro: ${snapshot.error}'));
+                }
+                if (snapshot.hasData) {
+                  // Filtrar a lista de mídias para conter apenas filmes
+                  List<dynamic> filteredMediaItems = snapshot.data!
+                      .where((media) => media is PopularMovie)
+                      .toList();
+                  return WidgetGridViewVertical(mediaItems: filteredMediaItems);
+                } else {
+                  return const Center(child: Text('Nenhum dado disponível'));
+                }
+              } else {
+                return const Center(child: CircularProgressIndicator());
+              }
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/view/see_all_popular_movies.dart
+++ b/lib/view/see_all_popular_movies.dart
@@ -1,0 +1,42 @@
+import 'package:dart_plus_app/classes/popular_movies.dart';
+import 'package:dart_plus_app/widgets/search_bar.dart';
+import 'package:dart_plus_app/widgets/title_section.dart';
+import 'package:dart_plus_app/data/mock/fetch/localdataservice.dart';
+import 'package:dart_plus_app/widgets/grid_view_vertical.dart';
+import 'package:flutter/material.dart';
+
+class SeeAllPopularMovies extends StatefulWidget {
+  const SeeAllPopularMovies({super.key, required this.title});
+  final String title;
+
+  @override
+  State<SeeAllPopularMovies> createState() => _SeeAllPopularMovies();
+}
+
+class _SeeAllPopularMovies extends State<SeeAllPopularMovies> {
+  late Future<List<dynamic>> mediaItems;
+
+  @override
+  void initState() {
+    super.initState();
+    mediaItems = LocalDataService().fetchData();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.background,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {},
+        ),
+        title: const WidgetTitleSection(title: 'Filmes Populares'),
+        actions: [IconButton(onPressed: () {}, icon: Icon(Icons.search))],
+      ),
+      body: Column(
+        children: [],
+      ),
+    );
+  }
+}

--- a/lib/view/see_all_popular_series.dart
+++ b/lib/view/see_all_popular_series.dart
@@ -1,0 +1,62 @@
+import 'package:dart_plus_app/classes/popular_series.dart';
+import 'package:dart_plus_app/widgets/title_section.dart';
+import 'package:dart_plus_app/data/mock/fetch/localdataservice.dart';
+import 'package:dart_plus_app/widgets/grid_view_vertical.dart';
+import 'package:flutter/material.dart';
+
+class SeeAllPopularSeries extends StatefulWidget {
+  const SeeAllPopularSeries({super.key, required this.title});
+  final String title;
+
+  @override
+  State<SeeAllPopularSeries> createState() => _SeeAllPopularSeries();
+}
+
+class _SeeAllPopularSeries extends State<SeeAllPopularSeries> {
+  late Future<List<dynamic>> mediaItems;
+
+  @override
+  void initState() {
+    super.initState();
+    mediaItems = LocalDataService().fetchData();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.background,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {},
+        ),
+        title: const WidgetTitleSection(title: 'Séries Populares'),
+        actions: [IconButton(onPressed: () {}, icon: Icon(Icons.search))],
+      ),
+      body: Column(
+        children: [
+          FutureBuilder<List<dynamic>>(
+            future: mediaItems,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.hasError) {
+                  return Center(child: Text('Erro: ${snapshot.error}'));
+                }
+                if (snapshot.hasData) {
+                  List<dynamic> filteredMediaItems = snapshot.data!
+                      .where((media) => media is PopularSeries)
+                      .toList();
+                  return WidgetGridViewVertical(mediaItems: filteredMediaItems);
+                } else {
+                  return const Center(child: Text('Nenhum dado disponível'));
+                }
+              } else {
+                return const Center(child: CircularProgressIndicator());
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Objetivo da Tarefa
- Criar a UI do página ver todos de filmes populares.

## O que foi feito 
- Adicionado à appBar:
    - ícone de voltar;
    - título;
    - ícone de procura.
    
- Adicionado ao corpo:
     - O widget do tipo gridView, que recebe uma lista filtrada só de filmes.
  